### PR TITLE
Add SphereAdapter and generalize shape interface

### DIFF
--- a/docs/MECHANICS.md
+++ b/docs/MECHANICS.md
@@ -13,6 +13,12 @@
 - Hitting your own body results in a game over.
 - Crossing an edge wraps the snake to the adjacent cube face.
 
+## Sphere Surface
+
+- When using `SphereAdapter`, the grid wraps seamlessly in both directions.
+- All cells use a single face index `0`.
+- The snake can travel endlessly around the sphere with no edges.
+
 ## Fruit
 
 - Fruit spawns in any free cell.

--- a/src/core/Grid.ts
+++ b/src/core/Grid.ts
@@ -1,17 +1,17 @@
 export type Cell = { face: number; u: number; v: number };
 export type Direction = 'up' | 'down' | 'left' | 'right';
 
-import { CubeAdapter } from '../shapes/CubeAdapter';
+import type { IShapeAdapter } from '../shapes/IShapeAdapter';
 
 export class Grid {
   constructor(
     public size: number,
-    private adapter: CubeAdapter
+    private adapter: IShapeAdapter
   ) {}
 
   randomCell(excluded: Cell[]): Cell {
     const cells: Cell[] = [];
-    for (let face = 0; face < 6; face++) {
+    for (let face = 0; face < this.adapter.getFaceCount(); face++) {
       for (let u = 0; u < this.size; u++) {
         for (let v = 0; v < this.size; v++) {
           if (

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,13 @@ import { Grid } from './core/Grid';
 import { Snake } from './core/Snake';
 import { GameLoop } from './core/GameLoop';
 import { CubeAdapter } from './shapes/CubeAdapter';
+import { SphereAdapter } from './shapes/SphereAdapter';
 import { GameRenderer } from './render/GameRenderer';
 import { Fruit } from './core/Fruit';
 import { Input } from './core/Input';
 
-const adapter = new CubeAdapter(5);
+const shape = new URLSearchParams(window.location.search).get('shape');
+const adapter = shape === 'sphere' ? new SphereAdapter(5) : new CubeAdapter(5);
 const grid = new Grid(5, adapter);
 const snake = new Snake({ face: 0, u: 2, v: 2 });
 const fruit = new Fruit(grid);

--- a/src/render/GameRenderer.ts
+++ b/src/render/GameRenderer.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import type { Snake } from '../core/Snake';
 import type { Fruit } from '../core/Fruit';
-import { CubeAdapter } from '../shapes/CubeAdapter';
+import type { IShapeAdapter } from '../shapes/IShapeAdapter';
 
 export class GameRenderer {
   scene: THREE.Scene;
@@ -16,7 +16,7 @@ export class GameRenderer {
   constructor(
     private snake: Snake,
     private fruit: Fruit,
-    private adapter: CubeAdapter,
+    private adapter: IShapeAdapter,
     withControls = false
   ) {
     this.scene = new THREE.Scene();

--- a/src/shapes/CubeAdapter.ts
+++ b/src/shapes/CubeAdapter.ts
@@ -9,6 +9,10 @@ export class CubeAdapter implements IShapeAdapter {
     return { u: this.size, v: this.size };
   }
 
+  getFaceCount() {
+    return 6;
+  }
+
   toWorld(cell: Cell): THREE.Vector3 {
     const offset = this.size / 2 - 0.5;
     const x = cell.u - offset;

--- a/src/shapes/IShapeAdapter.ts
+++ b/src/shapes/IShapeAdapter.ts
@@ -4,6 +4,8 @@ import type { Cell, Direction } from '../core/Grid';
 
 export interface IShapeAdapter {
   getGridSize(): { u: number; v: number };
+  /** Number of faces used by this adapter. */
+  getFaceCount(): number;
   toWorld(cell: Cell): THREE.Vector3;
   wrap(cell: Cell, dir: Direction): Cell;
 }

--- a/src/shapes/SphereAdapter.ts
+++ b/src/shapes/SphereAdapter.ts
@@ -1,0 +1,40 @@
+import * as THREE from 'three';
+import type { Cell, Direction } from '../core/Grid';
+import type { IShapeAdapter } from './IShapeAdapter';
+
+/**
+ * Maps grid coordinates onto a sphere using an equirectangular projection.
+ * The sphere uses a single face index (0) for all cells.
+ */
+export class SphereAdapter implements IShapeAdapter {
+  private radius: number;
+  constructor(private size = 10, radius?: number) {
+    this.radius = radius ?? size / Math.PI;
+  }
+
+  getGridSize() {
+    return { u: this.size, v: this.size };
+  }
+
+  getFaceCount() {
+    return 1;
+  }
+
+  toWorld(cell: Cell): THREE.Vector3 {
+    const phi = (cell.u + 0.5) * (2 * Math.PI / this.size);
+    const theta = (cell.v + 0.5) * (Math.PI / this.size);
+    const x = this.radius * Math.sin(theta) * Math.cos(phi);
+    const y = this.radius * Math.cos(theta);
+    const z = this.radius * Math.sin(theta) * Math.sin(phi);
+    return new THREE.Vector3(x, y, z);
+  }
+
+  // direction is ignored because wrapping on a sphere is uniform
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  wrap(cell: Cell, _dir: Direction): Cell {
+    let { u, v } = cell;
+    u = (u + this.size) % this.size;
+    v = (v + this.size) % this.size;
+    return { face: 0, u, v };
+  }
+}

--- a/tests/SphereAdapter.spec.ts
+++ b/tests/SphereAdapter.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { SphereAdapter } from '../src/shapes/SphereAdapter';
+
+describe('SphereAdapter wrap', () => {
+  const adapter = new SphereAdapter(4);
+  it('wraps horizontally', () => {
+    const start = { face: 0, u: 0, v: 0 };
+    const wrapped = adapter.wrap({ ...start, u: -1 }, 'left');
+    expect(wrapped.u).toBe(3);
+    expect(wrapped.v).toBe(start.v);
+    expect(wrapped.face).toBe(0);
+  });
+
+  it('wraps vertically', () => {
+    const start = { face: 0, u: 2, v: 0 };
+    const wrapped = adapter.wrap({ ...start, v: -1 }, 'up');
+    expect(wrapped.v).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- implement SphereAdapter for spherical grid mapping
- generalize `Grid` and `GameRenderer` to use `IShapeAdapter`
- expose face count in adapter interface
- select sphere or cube adapter via URL parameter
- document sphere surface behavior
- add unit tests for SphereAdapter

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857be13e7548324832769e1ecd58b18