### PR TITLE
Fix EventTarget usage

### DIFF
--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -32,7 +32,7 @@ export class GameLoop extends EventTarget {
       this.accumulator += delta;
       while (this.accumulator >= GameLoop.TICK) {
         this.update(GameLoop.TICK / 1000);
-        this.emit('tick');
+        this.dispatchEvent(new Event('tick'));
         this.accumulator -= GameLoop.TICK;
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,6 @@ const loop = new GameLoop(() => {
 
 new Input(snake, () => loop.togglePause());
 const renderer = new GameRenderer(snake, fruit, adapter, true);
-loop.on('tick', () => renderer.update());
+loop.addEventListener('tick', () => renderer.update());
 loop.start();
 


### PR DESCRIPTION
## Summary
- dispatch 'tick' events using standard DOM API
- register tick listener with `addEventListener`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6857c02c320483248b9076d06e715e14