### PR TITLE
Fix GameLoop event methods

### DIFF
--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -25,6 +25,14 @@ export class GameLoop extends EventTarget {
       this.state === GameState.RUNNING ? GameState.PAUSED : GameState.RUNNING;
   }
 
+  on(type: string, listener: EventListenerOrEventListenerObject) {
+    this.addEventListener(type, listener);
+  }
+
+  emit(type: string) {
+    this.dispatchEvent(new Event(type));
+  }
+
   private tick = (time: number) => {
     const delta = time - this.lastTime;
     this.lastTime = time;


### PR DESCRIPTION
## Summary
- ensure GameLoop exposes `on()` and `emit()` helpers for event handling

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c02c320483248b9076d06e715e14