### PR TITLE
Fix GameLoop event API

### DIFF
--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -14,6 +14,14 @@ export class GameLoop extends EventTarget {
     super();
   }
 
+  on(type: string, listener: EventListenerOrEventListenerObject) {
+    this.addEventListener(type, listener);
+  }
+
+  emit(type: string) {
+    this.dispatchEvent(new Event(type));
+  }
+
   start() {
     this.lastTime = performance.now();
     this.state = GameState.RUNNING;


### PR DESCRIPTION
## Summary
- add `on` and `emit` helpers to `GameLoop`

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`
- `python -m py_compile $(git ls-files '*.py')` *(no files found)*
- `python -m pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c02c320483248b9076d06e715e14