### PR TITLE
Implement score tracking for snake game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ Thumbs.db
 
 # Build output
 /dist
+__pycache__/
+python/**/__pycache__/
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Execute `npm test` to run the Vitest suite.
 ## How to Play
 
 Use the arrow keys or WASD to steer the snake. Press the spacebar to pause or resume.
-Eat the red fruit to grow longer. Colliding with your own body ends the game.
+Eat the red fruit to grow longer and earn points. The current score is printed
+in the console when using the Python CLI. Colliding with your own body ends the
+game.
 
 ## Development
 

--- a/python/core/fruit.py
+++ b/python/core/fruit.py
@@ -1,19 +1,23 @@
 from dataclasses import dataclass
 from ..shapes.ishape_adapter import Cell
 from .grid import Grid
+from .score import Score
 
 
 @dataclass
 class Fruit:
     grid: Grid
     cell: Cell
+    score: Score
 
-    def __init__(self, grid: Grid) -> None:
+    def __init__(self, grid: Grid, score: Score) -> None:
         self.grid = grid
+        self.score = score
         self.cell = Cell(0, 0, 0)
 
     def spawn(self, snake_body: list[Cell]) -> None:
         self.cell = self.grid.random_cell(snake_body)
 
     def eat(self) -> None:
-        pass
+        """Increment score when the fruit is consumed."""
+        self.score.increment()

--- a/python/core/score.py
+++ b/python/core/score.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Score:
+    value: int = 0
+
+    def increment(self) -> None:
+        self.value += 1

--- a/run_snake.py
+++ b/run_snake.py
@@ -2,6 +2,7 @@
 from python.core.grid import Grid
 from python.core.snake import Snake
 from python.core.fruit import Fruit
+from python.core.score import Score
 from python.core.game_loop import GameLoop, GameState
 from python.shapes.cube_adapter import CubeAdapter
 from python.shapes.sphere_adapter import SphereAdapter
@@ -12,7 +13,8 @@ def main(shape: str = "cube") -> None:
     adapter = SphereAdapter(5) if shape == "sphere" else CubeAdapter(5)
     grid = Grid(5, adapter)
     snake = Snake([Cell(0, 2, 2)])
-    fruit = Fruit(grid)
+    score = Score()
+    fruit = Fruit(grid, score)
     fruit.spawn(snake.body)
 
     def update(_dt: float) -> None:
@@ -29,7 +31,7 @@ def main(shape: str = "cube") -> None:
             snake.grow()
             fruit.spawn(snake.body)
             fruit.eat()
-        print(f"Snake: {snake.body} Fruit: {fruit.cell}")
+        print(f"Snake: {snake.body} Fruit: {fruit.cell} Score: {score.value}")
 
     loop = GameLoop(update)
     loop.start()

--- a/src/core/Fruit.ts
+++ b/src/core/Fruit.ts
@@ -1,10 +1,11 @@
 import type { Cell } from './Grid';
 import { Grid } from './Grid';
+import { Score } from './Score';
 
 export class Fruit extends EventTarget {
   cell: Cell;
 
-  constructor(private grid: Grid) {
+  constructor(private grid: Grid, private score: Score) {
     super();
     this.cell = { face: 0, u: 0, v: 0 };
   }
@@ -14,6 +15,7 @@ export class Fruit extends EventTarget {
   }
 
   eat() {
+    this.score.increment();
     this.dispatchEvent(new Event('fruit-eaten'));
   }
 }

--- a/src/core/Score.ts
+++ b/src/core/Score.ts
@@ -1,0 +1,7 @@
+export class Score {
+  value = 0;
+
+  increment() {
+    this.value += 1;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,13 +5,15 @@ import { CubeAdapter } from './shapes/CubeAdapter';
 import { SphereAdapter } from './shapes/SphereAdapter';
 import { GameRenderer } from './render/GameRenderer';
 import { Fruit } from './core/Fruit';
+import { Score } from './core/Score';
 import { Input } from './core/Input';
 
 const shape = new URLSearchParams(window.location.search).get('shape');
 const adapter = shape === 'sphere' ? new SphereAdapter(5) : new CubeAdapter(5);
 const grid = new Grid(5, adapter);
 const snake = new Snake({ face: 0, u: 2, v: 2 });
-const fruit = new Fruit(grid);
+const score = new Score();
+const fruit = new Fruit(grid, score);
 fruit.spawn(snake.body);
 
 const loop = new GameLoop(() => {
@@ -29,6 +31,7 @@ const loop = new GameLoop(() => {
     snake.grow();
     fruit.spawn(snake.body);
     fruit.eat();
+    console.log(`Score: ${score.value}`);
   }
 });
 

--- a/tests_py/test_fruit.py
+++ b/tests_py/test_fruit.py
@@ -1,0 +1,14 @@
+from python.core.grid import Grid
+from python.core.fruit import Fruit
+from python.core.score import Score
+from python.shapes.cube_adapter import CubeAdapter
+
+
+def test_score_increments_on_eat():
+    adapter = CubeAdapter(3)
+    grid = Grid(3, adapter)
+    score = Score()
+    fruit = Fruit(grid, score)
+    fruit.spawn([])
+    fruit.eat()
+    assert score.value == 1


### PR DESCRIPTION
## Summary
- add a new `Score` class for tallying points
- track score in both Python and TypeScript implementations
- update CLI to display the current score
- document scoring in README
- add unit test for score increment

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68581ad3898483248f243559ad2e8d4a