### PR TITLE
Implement fruit eaten event and scoring example

### DIFF
--- a/python/core/fruit.py
+++ b/python/core/fruit.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from typing import Callable, List
+
 from ..shapes.ishape_adapter import Cell
 from .grid import Grid
 
@@ -7,13 +9,20 @@ from .grid import Grid
 class Fruit:
     grid: Grid
     cell: Cell
+    _listeners: List[Callable[[], None]]
 
     def __init__(self, grid: Grid) -> None:
         self.grid = grid
         self.cell = Cell(0, 0, 0)
+        self._listeners = []
 
     def spawn(self, snake_body: list[Cell]) -> None:
         self.cell = self.grid.random_cell(snake_body)
 
+    def on_eaten(self, callback: Callable[[], None]) -> None:
+        """Register a callback fired when the fruit is eaten."""
+        self._listeners.append(callback)
+
     def eat(self) -> None:
-        pass
+        for cb in list(self._listeners):
+            cb()

--- a/run_snake.py
+++ b/run_snake.py
@@ -15,6 +15,15 @@ def main(shape: str = "cube") -> None:
     fruit = Fruit(grid)
     fruit.spawn(snake.body)
 
+    score = 0
+
+    def on_fruit_eaten() -> None:
+        nonlocal score
+        score += 1
+        print(f"Score: {score}")
+
+    fruit.on_eaten(on_fruit_eaten)
+
     def update(_dt: float) -> None:
         next_cell = grid.get_neighbor(snake.body[0], snake.direction)
         if snake.hits_self(next_cell):

--- a/tests_py/test_fruit.py
+++ b/tests_py/test_fruit.py
@@ -1,0 +1,19 @@
+from python.core.grid import Grid
+from python.core.fruit import Fruit
+from python.shapes.cube_adapter import CubeAdapter
+from python.shapes.ishape_adapter import Cell
+
+
+def test_fruit_eat_calls_listener():
+    adapter = CubeAdapter(3)
+    grid = Grid(3, adapter)
+    fruit = Fruit(grid)
+    fruit.spawn([Cell(0, 0, 0)])
+    called = []
+
+    def on_eat():
+        called.append(True)
+
+    fruit.on_eaten(on_eat)
+    fruit.eat()
+    assert called == [True]


### PR DESCRIPTION
## Summary
- implement event callbacks for `Fruit`
- track score in CLI example when fruit is eaten
- add unit test covering new `Fruit` behavior

## Testing
- `python -m pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68581ad3898483248f243559ad2e8d4a