### PR TITLE
Implement scoring for Fruit

### DIFF
--- a/python/core/fruit.py
+++ b/python/core/fruit.py
@@ -7,13 +7,15 @@ from .grid import Grid
 class Fruit:
     grid: Grid
     cell: Cell
+    score: int
 
     def __init__(self, grid: Grid) -> None:
         self.grid = grid
         self.cell = Cell(0, 0, 0)
+        self.score = 0
 
     def spawn(self, snake_body: list[Cell]) -> None:
         self.cell = self.grid.random_cell(snake_body)
 
     def eat(self) -> None:
-        pass
+        self.score += 1

--- a/run_snake.py
+++ b/run_snake.py
@@ -29,7 +29,9 @@ def main(shape: str = "cube") -> None:
             snake.grow()
             fruit.spawn(snake.body)
             fruit.eat()
-        print(f"Snake: {snake.body} Fruit: {fruit.cell}")
+        print(
+            f"Snake: {snake.body} Fruit: {fruit.cell} Score: {fruit.score}"
+        )
 
     loop = GameLoop(update)
     loop.start()

--- a/tests_py/test_fruit.py
+++ b/tests_py/test_fruit.py
@@ -1,0 +1,25 @@
+from python.core.grid import Grid
+from python.shapes.cube_adapter import CubeAdapter
+from python.core.fruit import Fruit
+from python.shapes.ishape_adapter import Cell
+
+
+def test_fruit_spawn_not_on_snake():
+    adapter = CubeAdapter(3)
+    grid = Grid(3, adapter)
+    fruit = Fruit(grid)
+    snake_body = [Cell(0, 0, 0), Cell(0, 1, 0), Cell(0, 2, 0)]
+    fruit.spawn(snake_body)
+    assert not any(
+        fruit.cell.face == c.face and fruit.cell.u == c.u and fruit.cell.v == c.v
+        for c in snake_body
+    )
+
+
+def test_fruit_score_increment():
+    adapter = CubeAdapter(2)
+    grid = Grid(2, adapter)
+    fruit = Fruit(grid)
+    assert fruit.score == 0
+    fruit.eat()
+    assert fruit.score == 1


### PR DESCRIPTION
## Summary
- track score in `Fruit`
- print score in CLI runner
- test `Fruit` spawn and scoring

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581ad3898483248f243559ad2e8d4a