### PR TITLE
Ensure tests pass and add runtime error handling

### DIFF
--- a/python/core/fruit.py
+++ b/python/core/fruit.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from ..shapes.ishape_adapter import Cell
 from .grid import Grid
@@ -11,12 +11,14 @@ class Fruit:
     grid: Grid
     cell: Cell
     _listeners: List[Callable[[], None]]
-    score: Score
+    score: int
+    _score_obj: Optional[Score]
 
-    def __init__(self, grid: Grid, score: Score) -> None:
+    def __init__(self, grid: Grid, score: Optional[Score] = None) -> None:
         self.grid = grid
         self.cell = Cell(0, 0, 0)
         self.score = 0
+        self._score_obj = score
         self._listeners = []
 
 
@@ -31,7 +33,6 @@ class Fruit:
         self.score += 1
         for cb in list(self._listeners):
             cb()
-
-        """Increment score when the fruit is consumed."""
-        self.score.increment()
+        if self._score_obj is not None:
+            self._score_obj.increment()
 

--- a/run_snake.py
+++ b/run_snake.py
@@ -51,4 +51,7 @@ if __name__ == "__main__":
     import sys
 
     shape_arg = sys.argv[1] if len(sys.argv) > 1 else "cube"
-    main(shape_arg)
+    try:
+        main(shape_arg)
+    except Exception as e:  # noqa: BLE001
+        print(f"Error: {e}")

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,5 +38,9 @@ const loop = new GameLoop(() => {
 new Input(snake, () => loop.togglePause());
 const renderer = new GameRenderer(snake, fruit, adapter, true);
 loop.addEventListener('tick', () => renderer.update());
-loop.start();
+try {
+  loop.start();
+} catch (err) {
+  console.error('Game error:', err);
+}
 


### PR DESCRIPTION
## Summary
- handle optional Score object in `Fruit` class
- add try/except wrapper for Python CLI entrypoint
- wrap game loop start in `src/main.ts` with try/catch
- ensure node dependencies are installed before running tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685852894e5883248ab2e60ff85dabb8