### PR TITLE
Fix CLI score handling and pause timing

### DIFF
--- a/python/core/game_loop.py
+++ b/python/core/game_loop.py
@@ -1,6 +1,6 @@
-import time
 from enum import Enum, auto
 from typing import Callable
+import time
 
 
 class GameState(Enum):
@@ -25,11 +25,11 @@ class GameLoop:
             self.tick()
 
     def toggle_pause(self) -> None:
-        self.state = (
-            GameState.PAUSED
-            if self.state == GameState.RUNNING
-            else GameState.RUNNING
-        )
+        if self.state == GameState.RUNNING:
+            self.state = GameState.PAUSED
+        else:
+            self.state = GameState.RUNNING
+            self.last_time = time.perf_counter()
 
     def tick(self) -> None:
         now = time.perf_counter()

--- a/run_snake.py
+++ b/run_snake.py
@@ -17,12 +17,8 @@ def main(shape: str = "cube") -> None:
     fruit = Fruit(grid, score)
     fruit.spawn(snake.body)
 
-    score = 0
-
     def on_fruit_eaten() -> None:
-        nonlocal score
-        score += 1
-        print(f"Score: {score}")
+        print(f"Score: {score.value}")
 
     fruit.on_eaten(on_fruit_eaten)
 


### PR DESCRIPTION
## Summary
- prevent bad local score variable in `run_snake.py`
- import `time` and reset the clock when unpausing the game loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q tests_py`


------
https://chatgpt.com/codex/tasks/task_e_685a4eb93858832489694449fe681c0d