### PR TITLE
Fix bug in CLI score tracking

### DIFF
--- a/run_snake.py
+++ b/run_snake.py
@@ -17,12 +17,8 @@ def main(shape: str = "cube") -> None:
     fruit = Fruit(grid, score)
     fruit.spawn(snake.body)
 
-    score = 0
-
     def on_fruit_eaten() -> None:
-        nonlocal score
-        score += 1
-        print(f"Score: {score}")
+        print(f"Score: {score.value}")
 
     fruit.on_eaten(on_fruit_eaten)
 


### PR DESCRIPTION
## Summary
- fix score handling in the `run_snake.py` demo

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `python run_snake.py cube` (manual, interrupted)

------
https://chatgpt.com/codex/tasks/task_e_685a4eb93858832489694449fe681c0d