### PR TITLE
Add CLI replay prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ with Vite for quick WebGL previews.
 Clone the repository and install dependencies with `npm install`.
 Run `npm run dev` to start the development server and open `localhost:5173` in your browser.
 Execute `npm test` to run the Vitest suite.
+You can also try the Python CLI version with `python run_snake.py cube` or `python run_snake.py sphere`.
+After each round it will prompt to play again.
 
 ## How to Play
 

--- a/run_snake.py
+++ b/run_snake.py
@@ -42,12 +42,18 @@ def main(shape: str = "cube") -> None:
     loop = GameLoop(update)
     loop.start()
 
+    print(f"Game Over! Final score: {score.value}")
+
 
 if __name__ == "__main__":
     import sys
 
     shape_arg = sys.argv[1] if len(sys.argv) > 1 else "cube"
-    try:
-        main(shape_arg)
-    except Exception as e:  # noqa: BLE001
-        print(f"Error: {e}")
+    while True:
+        try:
+            main(shape_arg)
+        except Exception as e:  # noqa: BLE001
+            print(f"Error: {e}")
+        again = input("Play again? (y/n): ").strip().lower()
+        if again != "y":
+            break


### PR DESCRIPTION
## Summary
- print a final score message at the end of `run_snake.py`
- allow replay from the command line
- document Python CLI usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685b50b781088324bb7422c41c0c8680