### PR TITLE
Fix snake direction delay

### DIFF
--- a/python/core/snake.py
+++ b/python/core/snake.py
@@ -23,11 +23,13 @@ class Snake:
             or (self.direction == 'right' and direction == 'left')
         )
 
-    def step(self, next_head: Cell) -> None:
+    def apply_next_direction(self) -> None:
         if self.next_directions:
             next_dir = self.next_directions.pop(0)
             if not self.is_opposite(next_dir):
                 self.direction = next_dir
+
+    def step(self, next_head: Cell) -> None:
         self.body.insert(0, next_head)
         if not self.grow_flag:
             self.body.pop()

--- a/run_snake.py
+++ b/run_snake.py
@@ -23,6 +23,7 @@ def main(shape: str = "cube") -> None:
     fruit.on_eaten(on_fruit_eaten)
 
     def update(_dt: float) -> None:
+        snake.apply_next_direction()
         next_cell = grid.get_neighbor(snake.body[0], snake.direction)
         if snake.hits_self(next_cell):
             loop.state = GameState.GAME_OVER

--- a/src/core/Snake.ts
+++ b/src/core/Snake.ts
@@ -15,14 +15,16 @@ export class Snake {
     this.nextDirections.push(dir);
   }
 
-  step(nextHead: Cell) {
+  applyNextDirection() {
     if (this.nextDirections.length > 0) {
       const next = this.nextDirections.shift()!;
       if (!this.isOpposite(next)) {
         this.direction = next;
       }
     }
+  }
 
+  step(nextHead: Cell) {
     this.body.unshift(nextHead);
     if (!this.growFlag) {
       this.body.pop();

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ function resetGame() {
 }
 
 const loop = new GameLoop(() => {
+  snake.applyNextDirection();
   const next = grid.getNeighbor(snake.body[0], snake.direction);
   if (snake.hitsSelf(next)) {
     loop.state = 2; // GAME_OVER

--- a/tests/Snake.spec.ts
+++ b/tests/Snake.spec.ts
@@ -23,4 +23,13 @@ describe('Snake mechanics', () => {
     next = grid.getNeighbor(snake.body[0], 'left');
     expect(snake.hitsSelf(next)).toBe(true);
   });
+
+  it('applies queued direction before moving', () => {
+    const snake = new Snake({ face: 0, u: 1, v: 1 });
+    snake.enqueueDirection('down');
+    snake.applyNextDirection();
+    const next = grid.getNeighbor(snake.body[0], snake.direction);
+    snake.step(next);
+    expect(snake.body[0]).toEqual({ face: 0, u: 1, v: 2 });
+  });
 });

--- a/tests_py/test_snake.py
+++ b/tests_py/test_snake.py
@@ -23,3 +23,14 @@ def test_detect_self_collision():
     snake.step(next_cell)
     next_cell = grid.get_neighbor(snake.body[0], 'left')
     assert snake.hits_self(next_cell)
+
+
+def test_direction_applied_before_move():
+    adapter = CubeAdapter(3)
+    grid = Grid(3, adapter)
+    snake = Snake([Cell(0, 1, 1)])
+    snake.enqueue_direction('down')
+    snake.apply_next_direction()
+    next_cell = grid.get_neighbor(snake.body[0], snake.direction)
+    snake.step(next_cell)
+    assert snake.body[0] == Cell(0, 1, 2)


### PR DESCRIPTION
## Summary
- apply queued direction before computing next move
- update CLI loop and main renderer
- add tests for immediate direction change

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7375bdac8324bb89a9f6708731fe