### PR TITLE
Fix Fruit score callback ordering

### DIFF
--- a/python/core/fruit.py
+++ b/python/core/fruit.py
@@ -31,8 +31,8 @@ class Fruit:
 
     def eat(self) -> None:
         self.score += 1
-        for cb in list(self._listeners):
-            cb()
         if self._score_obj is not None:
             self._score_obj.increment()
+        for cb in list(self._listeners):
+            cb()
 

--- a/tests_py/test_fruit.py
+++ b/tests_py/test_fruit.py
@@ -50,3 +50,19 @@ def test_score_increments_on_eat():
     fruit.eat()
     assert score.value == 1
 
+
+def test_eat_callback_sees_updated_score():
+    adapter = CubeAdapter(3)
+    grid = Grid(3, adapter)
+    score = Score()
+    fruit = Fruit(grid, score)
+    fruit.spawn([])
+    seen: list[int] = []
+
+    def on_eat() -> None:
+        seen.append(score.value)
+
+    fruit.on_eaten(on_eat)
+    fruit.eat()
+    assert seen == [1]
+


### PR DESCRIPTION
## Summary
- ensure score increments before calling fruit listeners
- test that eat callbacks receive updated score

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b7375bdac8324bb89a9f6708731fe