### PR TITLE
Fix GameLoop resume timing

### DIFF
--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -31,8 +31,12 @@ export class GameLoop extends EventTarget {
   }
 
   togglePause() {
-    this.state =
-      this.state === GameState.RUNNING ? GameState.PAUSED : GameState.RUNNING;
+    if (this.state === GameState.RUNNING) {
+      this.state = GameState.PAUSED;
+    } else {
+      this.state = GameState.RUNNING;
+      this.lastTime = performance.now();
+    }
   }
 
   private tick = (time: number) => {

--- a/tests/GameLoop.spec.ts
+++ b/tests/GameLoop.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { GameLoop, GameState } from '../src/core/GameLoop';
+
+// The GameLoop should reset lastTime when resuming from a pause so
+// accumulated time while paused does not trigger extra updates.
+
+describe('GameLoop togglePause', () => {
+  it('resets lastTime when unpausing', () => {
+    const loop = new GameLoop(() => {});
+    // loop starts paused by default
+    expect(loop.state).toBe(GameState.PAUSED);
+    loop.togglePause();
+    expect(loop.state).toBe(GameState.RUNNING);
+    expect(loop['lastTime']).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `GameLoop.togglePause` resets its internal timer when resuming
- add unit test covering this behaviour

## Testing
- `npm test --silent`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7375bdac8324bb89a9f6708731fe