### PR TITLE
Fix GameLoop resume timing

### DIFF
--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -31,8 +31,12 @@ export class GameLoop extends EventTarget {
   }
 
   togglePause() {
-    this.state =
-      this.state === GameState.RUNNING ? GameState.PAUSED : GameState.RUNNING;
+    if (this.state === GameState.RUNNING) {
+      this.state = GameState.PAUSED;
+    } else {
+      this.state = GameState.RUNNING;
+      this.lastTime = performance.now();
+    }
   }
 
   private tick = (time: number) => {

--- a/tests/GameLoop.spec.ts
+++ b/tests/GameLoop.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GameLoop, GameState } from '../src/core/GameLoop';
+
+// Access private field via casting
+function getLastTime(loop: GameLoop): number {
+  return (loop as unknown as { lastTime: number }).lastTime;
+}
+
+describe('GameLoop togglePause', () => {
+  it('sets lastTime when switching to RUNNING', () => {
+    const loop = new GameLoop(() => {});
+    expect(loop.state).toBe(GameState.PAUSED);
+    const spy = vi.spyOn(performance, 'now').mockReturnValue(123);
+    loop.togglePause();
+    expect(loop.state).toBe(GameState.RUNNING);
+    expect(getLastTime(loop)).toBe(123);
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- reset `lastTime` when toggling the loop back to `RUNNING`
- add regression test for `GameLoop.togglePause`

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b7375bdac8324bb89a9f6708731fe