### PR TITLE
Add GitHub CI workflows

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,23 @@
+name: Node CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run lint
+      - run: npm run build -- --mode test-render
+      - run: npm run test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,24 @@
+name: Python CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Lint and Test
+        run: |
+          python -m py_compile $(git ls-files '*.py')
+          python -m pytest -q


### PR DESCRIPTION
## Summary
- add Node.js workflow to run JS tests
- add Python workflow for pytest

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b7e208a808324abaa0843dd723546