### PR TITLE
Add AI integration test and workflow

### DIFF
--- a/.github/workflows/ai.yml
+++ b/.github/workflows/ai.yml
@@ -1,0 +1,21 @@
+name: AI Integration
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  ai-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run AI integration tests
+        run: |
+          python -m py_compile $(git ls-files '*.py')
+          python -m pytest -q tests_py/test_game_loop_ai.py

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python -m py_compile $(git ls-files '*.py')
 python -m pytest -q
 ```
 
-Both sets of tests run in CI to ensure the project stays stable.
+Both sets of tests run in CI, including a small AI integration test, to ensure the project stays stable.
 
 ## Python CLI
 

--- a/tests_py/test_game_loop_ai.py
+++ b/tests_py/test_game_loop_ai.py
@@ -1,0 +1,50 @@
+from python.core.grid import Grid
+from python.core.snake import Snake
+from python.core.fruit import Fruit
+from python.core.score import Score
+from python.core.game_loop import GameLoop, GameState
+from python.shapes.cube_adapter import CubeAdapter
+from python.shapes.ishape_adapter import Cell
+
+
+def test_game_loop_with_simple_ai():
+    adapter = CubeAdapter(3)
+    grid = Grid(3, adapter)
+    snake = Snake([Cell(0, 1, 1)])
+    score = Score()
+    fruit = Fruit(grid, score)
+    fruit.spawn(snake.body)
+
+    moves = ["right", "down", "left", "up", "right"]
+
+    def update(_dt: float) -> None:
+        if moves:
+            snake.enqueue_direction(moves.pop(0))
+        else:
+            loop.state = GameState.GAME_OVER
+            return
+        snake.apply_next_direction()
+        next_cell = grid.get_neighbor(snake.body[0], snake.direction)
+        if snake.hits_self(next_cell):
+            loop.state = GameState.GAME_OVER
+            return
+        snake.step(next_cell)
+        if (
+            next_cell.face == fruit.cell.face
+            and next_cell.u == fruit.cell.u
+            and next_cell.v == fruit.cell.v
+        ):
+            snake.grow()
+            fruit.spawn(snake.body)
+            fruit.eat()
+
+    loop = GameLoop(update)
+    loop.state = GameState.RUNNING
+    for _ in range(10):
+        loop.accumulator += GameLoop.TICK
+        loop.tick()
+        if loop.state == GameState.GAME_OVER:
+            break
+
+    assert score.value >= 0
+    assert len(snake.body) >= 1


### PR DESCRIPTION
## Summary
- add `AI Integration` workflow
- implement `test_game_loop_ai.py` with a dummy AI
- mention AI integration tests in README

## Testing
- `python -m pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685b9e2aa5348324bc9a966402e99f16