### PR TITLE
Improve CLI argument parsing in run_snake.py

### DIFF
--- a/run_snake.py
+++ b/run_snake.py
@@ -47,12 +47,23 @@ def main(shape: str = "cube") -> None:
 
 
 if __name__ == "__main__":
-    import sys
+    import argparse
 
-    shape_arg = sys.argv[1] if len(sys.argv) > 1 else "cube"
+    parser = argparse.ArgumentParser(
+        description="Run the Snake game on a cube or sphere surface."
+    )
+    parser.add_argument(
+        "shape",
+        nargs="?",
+        choices=["cube", "sphere"],
+        default="cube",
+        help="Surface shape to play on",
+    )
+    args = parser.parse_args()
+
     while True:
         try:
-            main(shape_arg)
+            main(args.shape)
         except Exception as e:  # noqa: BLE001
             print(f"Error: {e}")
         again = input("Play again? (y/n): ").strip().lower()


### PR DESCRIPTION
## Summary
- handle `--help` and invalid shapes via argparse

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685bc0f8365883249352ab4becfc1816