### PR TITLE
Improve CLI user exit handling

### DIFF
--- a/run_snake.py
+++ b/run_snake.py
@@ -53,6 +53,9 @@ if __name__ == "__main__":
     while True:
         try:
             main(shape_arg)
+        except KeyboardInterrupt:
+            print("Exiting...")
+            break
         except Exception as e:  # noqa: BLE001
             print(f"Error: {e}")
         again = input("Play again? (y/n): ").strip().lower()


### PR DESCRIPTION
## Summary
- handle `KeyboardInterrupt` in `run_snake.py` so exiting with Ctrl+C doesn't dump a traceback

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685bc0f8365883249352ab4becfc1816