### PR TITLE
Fix snake self collision detection

### DIFF
--- a/python/core/snake.py
+++ b/python/core/snake.py
@@ -40,11 +40,12 @@ class Snake:
         self.grow_flag = True
 
     def hits_self(self, cell: Cell) -> bool:
+        body = self.body if self.grow_flag else self.body[:-1]
         return any(
             c.face == cell.face
             and c.u == cell.u
             and c.v == cell.v
-            for c in self.body
+            for c in body
         )
 
     def out_of_bounds(self, cell: Cell, grid_size: int) -> bool:

--- a/src/core/Snake.ts
+++ b/src/core/Snake.ts
@@ -38,7 +38,8 @@ export class Snake {
   }
 
   hitsSelf(cell: Cell) {
-    return this.body.some(
+    const body = this.growFlag ? this.body : this.body.slice(0, -1);
+    return body.some(
       (c) => c.face === cell.face && c.u === cell.u && c.v === cell.v
     );
   }

--- a/tests_py/test_snake.py
+++ b/tests_py/test_snake.py
@@ -15,13 +15,14 @@ def test_snake_grows_after_eating():
 
 
 def test_detect_self_collision():
-    adapter = CubeAdapter(3)
-    grid = Grid(3, adapter)
-    snake = Snake([Cell(0, 1, 1)])
-    snake.grow()
-    next_cell = grid.get_neighbor(snake.body[0], 'right')
-    snake.step(next_cell)
-    next_cell = grid.get_neighbor(snake.body[0], 'left')
+    adapter = CubeAdapter(4)
+    grid = Grid(4, adapter)
+    snake = Snake([
+        Cell(0, 1, 1),
+        Cell(0, 1, 2),
+        Cell(0, 1, 3),
+    ])
+    next_cell = grid.get_neighbor(snake.body[0], 'down')
     assert snake.hits_self(next_cell)
 
 
@@ -34,3 +35,13 @@ def test_direction_applied_before_move():
     next_cell = grid.get_neighbor(snake.body[0], snake.direction)
     snake.step(next_cell)
     assert snake.body[0] == Cell(0, 1, 2)
+
+
+def test_moving_into_tail_not_self_collision():
+    adapter = CubeAdapter(3)
+    grid = Grid(3, adapter)
+    snake = Snake([Cell(0, 1, 1), Cell(0, 0, 1)])
+    snake.direction = 'left'
+    next_cell = grid.get_neighbor(snake.body[0], snake.direction)
+    assert next_cell == snake.body[-1]
+    assert not snake.hits_self(next_cell)


### PR DESCRIPTION
## Summary
- avoid false self-collision when stepping into the tail
- update TypeScript logic to match
- refine snake tests and add coverage for tail case

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bff3dd0c483249fcb27eebe6193dc