### PR TITLE
Fix self-collision detection

### DIFF
--- a/python/core/snake.py
+++ b/python/core/snake.py
@@ -40,11 +40,12 @@ class Snake:
         self.grow_flag = True
 
     def hits_self(self, cell: Cell) -> bool:
+        body = self.body if self.grow_flag else self.body[:-1]
         return any(
             c.face == cell.face
             and c.u == cell.u
             and c.v == cell.v
-            for c in self.body
+            for c in body
         )
 
     def out_of_bounds(self, cell: Cell, grid_size: int) -> bool:

--- a/src/core/Snake.ts
+++ b/src/core/Snake.ts
@@ -38,7 +38,8 @@ export class Snake {
   }
 
   hitsSelf(cell: Cell) {
-    return this.body.some(
+    const body = this.growFlag ? this.body : this.body.slice(0, -1);
+    return body.some(
       (c) => c.face === cell.face && c.u === cell.u && c.v === cell.v
     );
   }

--- a/tests/Snake.spec.ts
+++ b/tests/Snake.spec.ts
@@ -20,7 +20,10 @@ describe('Snake mechanics', () => {
     snake.grow();
     let next = grid.getNeighbor(snake.body[0], 'right');
     snake.step(next); // grow to length 2
-    next = grid.getNeighbor(snake.body[0], 'left');
+    snake.grow();
+    next = grid.getNeighbor(snake.body[0], 'down');
+    snake.step(next);
+    next = grid.getNeighbor(snake.body[0], 'up');
     expect(snake.hitsSelf(next)).toBe(true);
   });
 

--- a/tests_py/test_snake.py
+++ b/tests_py/test_snake.py
@@ -21,7 +21,10 @@ def test_detect_self_collision():
     snake.grow()
     next_cell = grid.get_neighbor(snake.body[0], 'right')
     snake.step(next_cell)
-    next_cell = grid.get_neighbor(snake.body[0], 'left')
+    snake.grow()
+    next_cell = grid.get_neighbor(snake.body[0], 'down')
+    snake.step(next_cell)
+    next_cell = grid.get_neighbor(snake.body[0], 'up')
     assert snake.hits_self(next_cell)
 
 


### PR DESCRIPTION
## Summary
- adjust `hits_self`/`hitsSelf` to ignore the tail when the snake isn't growing
- update Python and TypeScript self-collision tests

## Testing
- `python -m py_compile $(git ls-files '*.py') && python -m pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685bff3dd0c483249fcb27eebe6193dc