### PR TITLE
Fix renderer reset bug and add test

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ function resetGame() {
   score.value = 0;
   fruit.spawn(snake.body);
   scoreEl.textContent = 'Score: 0';
+  renderer.reset();
   loop.state = 1; // RUNNING
 }
 

--- a/src/render/GameRenderer.ts
+++ b/src/render/GameRenderer.ts
@@ -64,6 +64,39 @@ export class GameRenderer {
       this.scene.add(mesh);
       this.snakeMeshes.push(mesh);
     }
+    // Remove extra meshes when the snake shrinks (e.g., after reset)
+    while (this.snakeMeshes.length > this.snake.body.length) {
+      const mesh = this.snakeMeshes.pop();
+      if (mesh) {
+        this.scene.remove(mesh);
+        mesh.geometry.dispose();
+        if (Array.isArray(mesh.material)) {
+          mesh.material.forEach((m) => m.dispose());
+        } else {
+          mesh.material.dispose();
+        }
+      }
+    }
+  }
+
+  /**
+   * Reset the renderer to match the current snake state.
+   * Removes all segment meshes and recreates the initial head.
+   */
+  reset() {
+    for (const mesh of this.snakeMeshes) {
+      this.scene.remove(mesh);
+      mesh.geometry.dispose();
+      if (Array.isArray(mesh.material)) {
+        mesh.material.forEach((m) => m.dispose());
+      } else {
+        mesh.material.dispose();
+      }
+    }
+    this.snakeMeshes = [];
+    this.ensureSegments();
+    // Update fruit position as well
+    this.fruitMesh.position.copy(this.adapter.toWorld(this.fruit.cell));
   }
 
   update() {

--- a/tests/GameRendererReset.spec.ts
+++ b/tests/GameRendererReset.spec.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { Snake } from '../src/core/Snake';
+import { CubeAdapter } from '../src/shapes/CubeAdapter';
+import { Grid } from '../src/core/Grid';
+import { Fruit } from '../src/core/Fruit';
+import { Score } from '../src/core/Score';
+import { GameRenderer } from '../src/render/GameRenderer';
+
+vi.mock('three', async () => {
+  const actual = await vi.importActual<any>('three');
+  class FakeRenderer {
+    domElement = document.createElement('canvas');
+    setSize() {}
+    render() {}
+    dispose() {}
+  }
+  return { ...actual, WebGLRenderer: FakeRenderer };
+});
+
+describe('GameRenderer reset', () => {
+  it('removes extra meshes when the snake is reset', () => {
+    const adapter = new CubeAdapter(5);
+    const grid = new Grid(5, adapter);
+    const snake = new Snake({ face: 0, u: 2, v: 2 });
+    // create a longer snake
+    snake.body.push({ face: 0, u: 3, v: 2 }, { face: 0, u: 4, v: 2 });
+    const fruit = new Fruit(grid, new Score());
+    fruit.spawn(snake.body);
+    const renderer = new GameRenderer(snake, fruit, adapter, false);
+    renderer.update();
+    expect(renderer.snakeMeshes.length).toBe(3);
+
+    snake.body = [{ face: 0, u: 2, v: 2 }];
+    renderer.reset();
+    expect(renderer.snakeMeshes.length).toBe(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- dispose and recreate snake meshes on reset
- call renderer.reset from `resetGame`
- add regression test to ensure reset removes extra meshes

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d13871a20832483af2c40dd419ff3