### PR TITLE
Fix renderer reset cleanup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ function resetGame() {
   fruit.spawn(snake.body);
   scoreEl.textContent = 'Score: 0';
   loop.state = 1; // RUNNING
+  renderer.reset();
 }
 
 const loop = new GameLoop(() => {
@@ -51,9 +52,9 @@ const loop = new GameLoop(() => {
   }
 });
 
-new Input(snake, () => loop.togglePause(), resetGame);
 const renderer = new GameRenderer(snake, fruit, adapter, true);
 loop.addEventListener('tick', () => renderer.update());
+new Input(snake, () => loop.togglePause(), resetGame);
 try {
   loop.start();
 } catch (err) {


### PR DESCRIPTION
## Summary
- clean up stray snake meshes on reset
- sync renderer state after resetting game

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_685d13871a20832483af2c40dd419ff3