### PR TITLE
Improve adapter docs and renderer cleanup

### DIFF
--- a/python/shapes/cube_adapter.py
+++ b/python/shapes/cube_adapter.py
@@ -4,6 +4,8 @@ from .ishape_adapter import Cell, IShapeAdapter
 
 
 class CubeAdapter(IShapeAdapter):
+    """Adapter projecting grid cells onto a cube surface with edge wrapping."""
+
     def __init__(self, size: int = 10) -> None:
         self.size = size
 
@@ -14,6 +16,7 @@ class CubeAdapter(IShapeAdapter):
         return 6
 
     def to_world(self, cell: Cell) -> Tuple[float, float, float]:
+        """Convert a grid cell to world coordinates on the cube."""
         offset = self.size / 2 - 0.5
         x = cell.u - offset
         y = offset - cell.v
@@ -32,6 +35,7 @@ class CubeAdapter(IShapeAdapter):
         return (0.0, 0.0, 0.0)
 
     def wrap(self, cell: Cell, direction: str) -> Cell:
+        """Wrap a cell across cube faces when moving off an edge."""
         face = cell.face
         u = cell.u
         v = cell.v

--- a/python/shapes/sphere_adapter.py
+++ b/python/shapes/sphere_adapter.py
@@ -5,7 +5,7 @@ from .ishape_adapter import Cell, IShapeAdapter
 
 
 class SphereAdapter(IShapeAdapter):
-    """Equirectangular projection for a sphere."""
+    """Adapter using an equirectangular projection for a sphere surface."""
 
     def __init__(self, size: int = 10, radius: float | None = None) -> None:
         self.size = size
@@ -18,6 +18,7 @@ class SphereAdapter(IShapeAdapter):
         return 1
 
     def to_world(self, cell: Cell) -> Tuple[float, float, float]:
+        """Convert a grid cell to world coordinates on the sphere."""
         phi = (cell.u + 0.5) * (2 * math.pi / self.size)
         theta = (cell.v + 0.5) * (math.pi / self.size)
         x = self.radius * math.sin(theta) * math.cos(phi)
@@ -26,6 +27,7 @@ class SphereAdapter(IShapeAdapter):
         return (x, y, z)
 
     def wrap(self, cell: Cell, _direction: str) -> Cell:
+        """Wrap coordinates around the sphere uniformly."""
         u = (cell.u + self.size) % self.size
         v = (cell.v + self.size) % self.size
         return Cell(0, u, v)

--- a/src/render/GameRenderer.ts
+++ b/src/render/GameRenderer.ts
@@ -121,6 +121,9 @@ export class GameRenderer {
     this.scene.remove(this.fruitMesh);
     this.fruitMesh.geometry.dispose();
     (this.fruitMesh.material as THREE.Material).dispose();
+    if (this.controls) {
+      this.controls.dispose();
+    }
     this.renderer.dispose();
     if (this.dom.parentElement) {
       this.dom.parentElement.removeChild(this.dom);

--- a/src/shapes/CubeAdapter.ts
+++ b/src/shapes/CubeAdapter.ts
@@ -2,6 +2,10 @@ import * as THREE from 'three';
 import type { Cell, Direction } from '../core/Grid';
 import type { IShapeAdapter } from './IShapeAdapter';
 
+/**
+ * Projects grid coordinates onto the six faces of a cube. Wrapping logic maps
+ * movements across an edge to the adjacent face, preserving direction.
+ */
 export class CubeAdapter implements IShapeAdapter {
   constructor(private size = 10) {}
 
@@ -13,6 +17,7 @@ export class CubeAdapter implements IShapeAdapter {
     return 6;
   }
 
+  /** Convert a grid cell to world space on the cube surface. */
   toWorld(cell: Cell): THREE.Vector3 {
     const offset = this.size / 2 - 0.5;
     const x = cell.u - offset;
@@ -35,6 +40,10 @@ export class CubeAdapter implements IShapeAdapter {
     }
   }
 
+  /**
+   * Wrap a cell when moving off one face to the neighbor face. The direction
+   * determines which face transition to perform.
+   */
   wrap(cell: Cell, dir: Direction): Cell {
     const { face } = cell;
     let { u, v } = cell;

--- a/src/shapes/SphereAdapter.ts
+++ b/src/shapes/SphereAdapter.ts
@@ -20,6 +20,7 @@ export class SphereAdapter implements IShapeAdapter {
     return 1;
   }
 
+  /** Convert a grid cell to a position on the sphere surface. */
   toWorld(cell: Cell): THREE.Vector3 {
     const phi = (cell.u + 0.5) * (2 * Math.PI / this.size);
     const theta = (cell.v + 0.5) * (Math.PI / this.size);
@@ -29,7 +30,10 @@ export class SphereAdapter implements IShapeAdapter {
     return new THREE.Vector3(x, y, z);
   }
 
-  // direction is ignored because wrapping on a sphere is uniform
+  /**
+   * Wrap a cell around the sphere. Direction is ignored because all edges
+   * connect uniformly in an equirectangular projection.
+   */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   wrap(cell: Cell, _dir: Direction): Cell {
     let { u, v } = cell;


### PR DESCRIPTION
## Summary
- document cube and sphere adapter methods
- add disposal of orbit controls
- add Python docstrings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685d27adf6f08324a88c305fee6c55ca