### PR TITLE
Improve reset handling and renderer cleanup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -81,7 +81,7 @@ function startGame() {
   scoreEl.textContent = 'Score: 0';
   showInstructions();
   renderer.reset();
-  loop.state = 1; // RUNNING
+  loop.start();
 }
 
 function resetGame() {

--- a/src/render/GameRenderer.ts
+++ b/src/render/GameRenderer.ts
@@ -121,6 +121,10 @@ export class GameRenderer {
     this.scene.remove(this.fruitMesh);
     this.fruitMesh.geometry.dispose();
     (this.fruitMesh.material as THREE.Material).dispose();
+    this.scene.remove(this.light);
+    if (this.controls) {
+      this.controls.dispose();
+    }
     this.renderer.dispose();
     if (this.dom.parentElement) {
       this.dom.parentElement.removeChild(this.dom);

--- a/tests/GameRendererDispose.spec.ts
+++ b/tests/GameRendererDispose.spec.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { Snake } from '../src/core/Snake';
+import { CubeAdapter } from '../src/shapes/CubeAdapter';
+import { Grid } from '../src/core/Grid';
+import { Fruit } from '../src/core/Fruit';
+import { Score } from '../src/core/Score';
+import { GameRenderer } from '../src/render/GameRenderer';
+
+vi.mock('three', async () => {
+  const actual = await vi.importActual<any>('three');
+  class FakeRenderer {
+    domElement = document.createElement('canvas');
+    setSize() {}
+    render() {}
+    dispose() {}
+  }
+  return { ...actual, WebGLRenderer: FakeRenderer };
+});
+
+describe('GameRenderer dispose', () => {
+  it('removes canvas element and clears meshes', () => {
+    const adapter = new CubeAdapter(5);
+    const grid = new Grid(5, adapter);
+    const snake = new Snake({ face: 0, u: 2, v: 2 });
+    const fruit = new Fruit(grid, new Score());
+    fruit.spawn(snake.body);
+    const renderer = new GameRenderer(snake, fruit, adapter, false);
+    expect(document.querySelectorAll('canvas').length).toBe(1);
+    renderer.dispose();
+    expect(renderer.snakeMeshes.length).toBe(0);
+    expect(document.querySelectorAll('canvas').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure game loop starts via `loop.start()`
- dispose of controls and light in `GameRenderer`
- add regression test for renderer disposal

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d27adf6f08324a88c305fee6c55ca