### PR TITLE
Improve shape adapter documentation

### DIFF
--- a/python/shapes/cube_adapter.py
+++ b/python/shapes/cube_adapter.py
@@ -16,7 +16,11 @@ class CubeAdapter(IShapeAdapter):
         return 6
 
     def to_world(self, cell: Cell) -> Tuple[float, float, float]:
-        """Convert a grid cell to world coordinates on the cube."""
+        """Convert a grid cell to world coordinates on the cube.
+
+        The cube is centered at the origin. The ``u`` and ``v`` coordinates are
+        offset so that ``(0, 0)`` corresponds to the top-left of each face.
+        """
         offset = self.size / 2 - 0.5
         x = cell.u - offset
         y = offset - cell.v
@@ -35,7 +39,12 @@ class CubeAdapter(IShapeAdapter):
         return (0.0, 0.0, 0.0)
 
     def wrap(self, cell: Cell, direction: str) -> Cell:
-        """Wrap a cell across cube faces when moving off an edge."""
+        """Wrap a cell across cube faces when moving off an edge.
+
+        The movement direction determines which neighbouring face the cell
+        transitions to. Coordinates that don't result in a face change are
+        wrapped modulo the grid size on the current face.
+        """
         face = cell.face
         u = cell.u
         v = cell.v

--- a/python/shapes/cylinder_adapter.py
+++ b/python/shapes/cylinder_adapter.py
@@ -18,6 +18,11 @@ class CylinderAdapter(IShapeAdapter):
         return 3
 
     def to_world(self, cell: Cell) -> Tuple[float, float, float]:
+        """Convert a grid cell to world coordinates on the cylinder.
+
+        ``u`` controls rotation around the central axis while ``v`` maps either
+        to height (side) or radial distance (caps).
+        """
         angle = (cell.u + 0.5) * (2 * math.pi / self.size)
         offset = self.size / 2 - 0.5
         if cell.face == 0:  # side
@@ -40,6 +45,11 @@ class CylinderAdapter(IShapeAdapter):
         return (0.0, 0.0, 0.0)
 
     def wrap(self, cell: Cell, direction: str) -> Cell:
+        """Wrap coordinates across cylinder faces.
+
+        Moving past the top or bottom of the side face enters the respective
+        cap. Horizontal motion around the side wraps modulo the circumference.
+        """
         face = cell.face
         u = cell.u
         v = cell.v

--- a/python/shapes/sphere_adapter.py
+++ b/python/shapes/sphere_adapter.py
@@ -18,7 +18,11 @@ class SphereAdapter(IShapeAdapter):
         return 1
 
     def to_world(self, cell: Cell) -> Tuple[float, float, float]:
-        """Convert a grid cell to world coordinates on the sphere."""
+        """Convert a grid cell to world coordinates on the sphere.
+
+        ``u`` corresponds to longitude and ``v`` to latitude. Half-cell offsets
+        place the point at the centre of each surface patch.
+        """
         phi = (cell.u + 0.5) * (2 * math.pi / self.size)
         theta = (cell.v + 0.5) * (math.pi / self.size)
         x = self.radius * math.sin(theta) * math.cos(phi)
@@ -27,7 +31,12 @@ class SphereAdapter(IShapeAdapter):
         return (x, y, z)
 
     def wrap(self, cell: Cell, _direction: str) -> Cell:
-        """Wrap coordinates around the sphere uniformly."""
+        """Wrap coordinates around the sphere uniformly.
+
+        The direction argument is ignored because every edge connects
+        continuously on a sphere. ``u`` and ``v`` simply wrap modulo the grid
+        size.
+        """
         u = (cell.u + self.size) % self.size
         v = (cell.v + self.size) % self.size
         return Cell(0, u, v)

--- a/src/shapes/CubeAdapter.ts
+++ b/src/shapes/CubeAdapter.ts
@@ -17,7 +17,13 @@ export class CubeAdapter implements IShapeAdapter {
     return 6;
   }
 
-  /** Convert a grid cell to world space on the cube surface. */
+  /**
+   * Convert a grid cell to world space on the cube surface.
+   *
+   * The cube is centered at the origin with each face having a unit grid. The
+   * cell's `u` and `v` are offset so that (0,0) maps to the top-left corner of a
+   * face.
+   */
   toWorld(cell: Cell): THREE.Vector3 {
     const offset = this.size / 2 - 0.5;
     const x = cell.u - offset;
@@ -41,8 +47,11 @@ export class CubeAdapter implements IShapeAdapter {
   }
 
   /**
-   * Wrap a cell when moving off one face to the neighbor face. The direction
-   * determines which face transition to perform.
+   * Wrap a cell when moving off one face to its neighboring face.
+   *
+   * The mapping preserves movement direction so the snake seamlessly crosses
+   * cube edges. Coordinates that don't trigger a face change are wrapped modulo
+   * the grid size on the current face.
    */
   wrap(cell: Cell, dir: Direction): Cell {
     const { face } = cell;

--- a/src/shapes/CylinderAdapter.ts
+++ b/src/shapes/CylinderAdapter.ts
@@ -21,7 +21,12 @@ export class CylinderAdapter implements IShapeAdapter {
     return 3;
   }
 
-  /** Convert a grid cell to world space on the cylinder surface. */
+  /**
+   * Convert a grid cell to world space on the cylinder surface.
+   *
+   * `u` rotates around the cylinder's axis while `v` moves along the height.
+   * For the caps, `v` represents radial distance from the center.
+   */
   toWorld(cell: Cell): THREE.Vector3 {
     const angle = (cell.u + 0.5) * (2 * Math.PI / this.size);
     const offset = this.size / 2 - 0.5;
@@ -57,6 +62,10 @@ export class CylinderAdapter implements IShapeAdapter {
 
   /**
    * Wrap coordinates around the cylinder and between faces.
+   *
+   * When leaving the side at the top or bottom the cell transitions to the
+   * respective cap. Horizontal movement around the side wraps modulo the grid
+   * width.
    */
   wrap(cell: Cell, dir: Direction): Cell {
     const { face } = cell;

--- a/src/shapes/SphereAdapter.ts
+++ b/src/shapes/SphereAdapter.ts
@@ -20,10 +20,16 @@ export class SphereAdapter implements IShapeAdapter {
     return 1;
   }
 
-  /** Convert a grid cell to a position on the sphere surface. */
+  /**
+   * Convert a grid cell to a point on the sphere surface.
+   *
+   * `u` maps to longitude (phi) and `v` to latitude (theta) using an
+   * equirectangular projection. Half-cell offsets center the cell on the
+   * surface patch.
+   */
   toWorld(cell: Cell): THREE.Vector3 {
-    const phi = (cell.u + 0.5) * (2 * Math.PI / this.size);
-    const theta = (cell.v + 0.5) * (Math.PI / this.size);
+    const phi = (cell.u + 0.5) * (2 * Math.PI / this.size); // longitude
+    const theta = (cell.v + 0.5) * (Math.PI / this.size); // latitude
     const x = this.radius * Math.sin(theta) * Math.cos(phi);
     const y = this.radius * Math.cos(theta);
     const z = this.radius * Math.sin(theta) * Math.sin(phi);
@@ -31,8 +37,11 @@ export class SphereAdapter implements IShapeAdapter {
   }
 
   /**
-   * Wrap a cell around the sphere. Direction is ignored because all edges
-   * connect uniformly in an equirectangular projection.
+   * Wrap a cell around the sphere.
+   *
+   * Because the sphere has no edges, moving off one side simply wraps the
+   * coordinates modulo the grid size. The direction is unused but kept for
+   * parity with other adapters.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   wrap(cell: Cell, _dir: Direction): Cell {


### PR DESCRIPTION
## Summary
- expand doc comments for Cube/Sphere/Cylinder adapters in TypeScript
- add matching Python docstrings for shape adapters

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685def1c09688324b40f613a31ec3768