### PR TITLE
Fix input scroll bug

### DIFF
--- a/src/core/Input.ts
+++ b/src/core/Input.ts
@@ -26,12 +26,17 @@ export class Input {
       d: 'right',
     } as const;
 
+    if (e.key === ' ' || e.key === 'r' || map[e.key]) {
+      e.preventDefault();
+    }
+
     if (e.key === ' ') {
       this.onToggle();
     }
     if (e.key === 'r') {
       this.onReset();
     }
+
     const dir = map[e.key];
     if (dir) {
       this.snake.enqueueDirection(dir);

--- a/tests/Input.spec.ts
+++ b/tests/Input.spec.ts
@@ -8,10 +8,30 @@ describe('Input reset key', () => {
     const snake = new Snake({ face: 0, u: 0, v: 0 });
     let called = false;
     // eslint-disable-next-line no-new
-    new Input(snake, () => {}, () => {
-      called = true;
-    });
+    new Input(
+      snake,
+      () => {},
+      () => {
+        called = true;
+      }
+    );
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'r' }));
     expect(called).toBe(true);
+  });
+
+  it('prevents default browser actions for movement keys', () => {
+    const snake = new Snake({ face: 0, u: 0, v: 0 });
+    // eslint-disable-next-line no-new
+    new Input(
+      snake,
+      () => {},
+      () => {}
+    );
+    const evt = new KeyboardEvent('keydown', {
+      key: 'ArrowUp',
+      cancelable: true,
+    });
+    window.dispatchEvent(evt);
+    expect(evt.defaultPrevented).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- prevent default scroll behavior on keydown
- add unit test for keyboard default prevention

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685def1c09688324b40f613a31ec3768