### PR TITLE
Add mobile controls and basic AR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ fits together.
  - Start menu allows selecting **Cube**, **Sphere**, or **Cylinder** surface, grid size and speed.
 - On-screen instructions explain keyboard controls.
 - Game over overlay shows final score with a prompt to restart.
+- Optional WebXR button enables AR mode on supported devices.
+- Mobile play uses on-screen D-pad or swipe gestures.
 - Images below show these features in action.
 
 ## Getting Started
@@ -19,6 +21,7 @@ fits together.
 Clone the repository and install dependencies with `npm install`.
 Run `npm run dev` to start the development server and open `localhost:5173` in your browser.
 Execute `npm test` to run the Vitest suite.
+If your browser supports WebXR, an **Enter AR** button will appear once the game starts.
 You can also try the Python CLI version with `python run_snake.py cube`, `python run_snake.py sphere` or `python run_snake.py cylinder`.
 After each round it will prompt to play again.
 
@@ -35,6 +38,7 @@ Press **R** to reset the game after a game over.
 Eat the red fruit to grow longer and earn points. The current score is shown in the
 top-left corner when running the web version. Colliding with your own body ends the
 game.
+On touch devices you can swipe or use the on-screen D-pad. Moving your phone rotates the camera when not using mouse controls.
 
 When the page first loads you'll see a **start menu** where you can choose the
 surface shape, grid size and snake speed. After clicking Start, a short

--- a/index.html
+++ b/index.html
@@ -37,11 +37,31 @@
       #gameover {
         display: none;
       }
+      #dpad {
+        position: absolute;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+        user-select: none;
+      }
+      #dpad-row {
+        display: flex;
+        gap: 5px;
+        justify-content: center;
+      }
+      #dpad button {
+        width: 40px;
+        height: 40px;
+        font-size: 24px;
+      }
     </style>
   </head>
   <body>
     <div id="score">Score: 0</div>
-    <div id="instructions">Use Arrow keys/WASD to move. Space to pause. R to reset.</div>
+    <div id="instructions">Use Arrow keys/WASD or swipe to move. Space to pause. R to reset.</div>
     <div id="gameover"></div>
     <div id="menu">
       <form id="start-form">
@@ -62,6 +82,14 @@
         </div>
         <button type="submit">Start Game</button>
       </form>
+    </div>
+    <div id="dpad" style="display:none;">
+      <button id="dpad-up">▲</button>
+      <div id="dpad-row">
+        <button id="dpad-left">◀</button>
+        <button id="dpad-down">▼</button>
+        <button id="dpad-right">▶</button>
+      </div>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/core/Input.ts
+++ b/src/core/Input.ts
@@ -2,16 +2,29 @@ import type { Snake } from './Snake';
 import type { Direction } from './Grid';
 
 export class Input {
+  private touchX = 0;
+  private touchY = 0;
+  private upBtn?: HTMLElement;
+  private downBtn?: HTMLElement;
+  private leftBtn?: HTMLElement;
+  private rightBtn?: HTMLElement;
   constructor(
     private snake: Snake,
     private onToggle: () => void,
     private onReset: () => void
   ) {
     window.addEventListener('keydown', this.handleKey);
+    this.initTouch();
   }
 
   dispose() {
     window.removeEventListener('keydown', this.handleKey);
+    window.removeEventListener('touchstart', this.handleTouchStart);
+    window.removeEventListener('touchend', this.handleTouchEnd);
+    this.upBtn?.removeEventListener('touchstart', this.onUp);
+    this.downBtn?.removeEventListener('touchstart', this.onDown);
+    this.leftBtn?.removeEventListener('touchstart', this.onLeft);
+    this.rightBtn?.removeEventListener('touchstart', this.onRight);
   }
 
   handleKey = (e: KeyboardEvent) => {
@@ -41,5 +54,45 @@ export class Input {
     if (dir) {
       this.snake.enqueueDirection(dir);
     }
+  };
+
+  private initTouch() {
+    if (!('ontouchstart' in window)) return;
+    this.upBtn = document.getElementById('dpad-up') ?? undefined;
+    this.downBtn = document.getElementById('dpad-down') ?? undefined;
+    this.leftBtn = document.getElementById('dpad-left') ?? undefined;
+    this.rightBtn = document.getElementById('dpad-right') ?? undefined;
+    document.getElementById('dpad')?.removeAttribute('style');
+
+    this.upBtn?.addEventListener('touchstart', this.onUp);
+    this.downBtn?.addEventListener('touchstart', this.onDown);
+    this.leftBtn?.addEventListener('touchstart', this.onLeft);
+    this.rightBtn?.addEventListener('touchstart', this.onRight);
+
+    window.addEventListener('touchstart', this.handleTouchStart, { passive: false });
+    window.addEventListener('touchend', this.handleTouchEnd, { passive: false });
+  }
+
+  private onUp = () => this.snake.enqueueDirection('up');
+  private onDown = () => this.snake.enqueueDirection('down');
+  private onLeft = () => this.snake.enqueueDirection('left');
+  private onRight = () => this.snake.enqueueDirection('right');
+
+  private handleTouchStart = (e: TouchEvent) => {
+    if (e.touches.length > 0) {
+      this.touchX = e.touches[0].clientX;
+      this.touchY = e.touches[0].clientY;
+    }
+  };
+
+  private handleTouchEnd = (e: TouchEvent) => {
+    if (e.changedTouches.length === 0) return;
+    const dx = e.changedTouches[0].clientX - this.touchX;
+    const dy = e.changedTouches[0].clientY - this.touchY;
+    if (Math.abs(dx) < 20 && Math.abs(dy) < 20) return;
+    const dir = Math.abs(dx) > Math.abs(dy)
+      ? dx > 0 ? 'right' : 'left'
+      : dy > 0 ? 'down' : 'up';
+    this.snake.enqueueDirection(dir as Direction);
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,7 +81,11 @@ function startGame() {
 
   loop = new GameLoop(update);
   input = new Input(snake, () => loop.togglePause(), resetGame);
-  renderer = new GameRenderer(snake, fruit, adapter, true);
+  const useControls = !('ontouchstart' in window);
+  renderer = new GameRenderer(snake, fruit, adapter, useControls);
+  if (navigator.xr) {
+    renderer.enableAR();
+  }
   loop.addEventListener('tick', () => renderer.update());
 
   scoreEl.textContent = 'Score: 0';


### PR DESCRIPTION
## Summary
- integrate device orientation and AR button in `GameRenderer`
- enable touch D‑pad and swipe gestures in `Input`
- adjust game startup to pick controls based on device and enable AR when available
- update UI with instructions, D‑pad and AR notes

## Testing
- `npm run lint`
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685df8a2b8f88324a3bd2321c4bf141f