### PR TITLE
Fix snake direction reversal bug

### DIFF
--- a/python/core/snake.py
+++ b/python/core/snake.py
@@ -24,10 +24,12 @@ class Snake:
         )
 
     def apply_next_direction(self) -> None:
-        if self.next_directions:
+        """Apply the next queued direction, skipping opposites."""
+        while self.next_directions:
             next_dir = self.next_directions.pop(0)
             if not self.is_opposite(next_dir):
                 self.direction = next_dir
+                break
 
     def step(self, next_head: Cell) -> None:
         self.body.insert(0, next_head)

--- a/src/core/Snake.ts
+++ b/src/core/Snake.ts
@@ -10,16 +10,21 @@ export class Snake {
     this.body = [start];
   }
 
-
   enqueueDirection(dir: Direction) {
     this.nextDirections.push(dir);
   }
 
+  /**
+   * Apply the next queued direction, skipping any that would
+   * immediately reverse the current heading. This avoids
+   * accidental 180° turns when opposite inputs are queued.
+   */
   applyNextDirection() {
-    if (this.nextDirections.length > 0) {
+    while (this.nextDirections.length > 0) {
       const next = this.nextDirections.shift()!;
       if (!this.isOpposite(next)) {
         this.direction = next;
+        break;
       }
     }
   }

--- a/tests/Snake.spec.ts
+++ b/tests/Snake.spec.ts
@@ -35,4 +35,12 @@ describe('Snake mechanics', () => {
     snake.step(next);
     expect(snake.body[0]).toEqual({ face: 0, u: 1, v: 2 });
   });
+
+  it('skips opposite directions in the queue', () => {
+    const snake = new Snake({ face: 0, u: 1, v: 1 });
+    snake.enqueueDirection('left');
+    snake.enqueueDirection('up');
+    snake.applyNextDirection();
+    expect(snake.direction).toBe('up');
+  });
 });

--- a/tests_py/test_snake.py
+++ b/tests_py/test_snake.py
@@ -37,3 +37,13 @@ def test_direction_applied_before_move():
     next_cell = grid.get_neighbor(snake.body[0], snake.direction)
     snake.step(next_cell)
     assert snake.body[0] == Cell(0, 1, 2)
+
+
+def test_skips_opposite_in_queue():
+    adapter = CubeAdapter(3)
+    grid = Grid(3, adapter)
+    snake = Snake([Cell(0, 1, 1)])
+    snake.enqueue_direction('left')
+    snake.enqueue_direction('up')
+    snake.apply_next_direction()
+    assert snake.direction == 'up'


### PR DESCRIPTION
## Summary
- ignore queued directions that would reverse direction in both TypeScript and Python
- add regression tests for opposite-direction input handling

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685df8a2b8f88324a3bd2321c4bf141f