### PR TITLE
Improve event handling for pause and game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       #score,
       #instructions,
       #gameover,
+      #paused,
       #menu {
         position: absolute;
         left: 50%;
@@ -37,6 +38,10 @@
       #gameover {
         display: none;
       }
+      #paused {
+        display: none;
+      }
+
       #dpad {
         position: absolute;
         bottom: 20px;
@@ -62,6 +67,7 @@
   <body>
     <div id="score">Score: 0</div>
     <div id="instructions">Use Arrow keys/WASD or swipe to move. Space to pause. R to reset.</div>
+    <div id="paused">Game Paused</div>
     <div id="gameover"></div>
     <div id="menu">
       <form id="start-form">

--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -4,7 +4,11 @@ export enum GameState {
   GAME_OVER,
 }
 
-export type GameLoopEventType = 'tick';
+export type GameLoopEventType =
+  | 'tick'
+  | 'pause'
+  | 'resume'
+  | 'gameover';
 
 export class GameLoop extends EventTarget {
   static TICK = 150; // ms per move
@@ -28,6 +32,7 @@ export class GameLoop extends EventTarget {
   start() {
     this.lastTime = performance.now();
     this.state = GameState.RUNNING;
+    this.emit('resume');
     this.frame = requestAnimationFrame(this.tick);
   }
 
@@ -38,10 +43,17 @@ export class GameLoop extends EventTarget {
   togglePause() {
     if (this.state === GameState.RUNNING) {
       this.state = GameState.PAUSED;
+      this.emit('pause');
     } else {
       this.state = GameState.RUNNING;
       this.lastTime = performance.now();
+      this.emit('resume');
     }
+  }
+
+  gameOver() {
+    this.state = GameState.GAME_OVER;
+    this.emit('gameover');
   }
 
   private tick = (time: number) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { Grid } from './core/Grid';
 import { Snake } from './core/Snake';
-import { GameLoop, GameState } from './core/GameLoop';
+import { GameLoop } from './core/GameLoop';
 import { CubeAdapter } from './shapes/CubeAdapter';
 import { SphereAdapter } from './shapes/SphereAdapter';
 import { CylinderAdapter } from './shapes/CylinderAdapter';
@@ -12,6 +12,7 @@ import { Input } from './core/Input';
 const scoreEl = document.getElementById('score') as HTMLDivElement;
 const instructionsEl = document.getElementById('instructions') as HTMLDivElement;
 const gameoverEl = document.getElementById('gameover') as HTMLDivElement;
+const pausedEl = document.getElementById('paused') as HTMLDivElement;
 const menuEl = document.getElementById('menu') as HTMLDivElement;
 const form = document.getElementById('start-form') as HTMLFormElement;
 const shapeSelect = document.getElementById('shape-select') as HTMLSelectElement;
@@ -37,6 +38,7 @@ function showInstructions() {
 function startGame() {
   menuEl.style.display = 'none';
   gameoverEl.style.display = 'none';
+  pausedEl.style.display = 'none';
 
   const size = parseInt(gridInput.value, 10);
   const speed = parseInt(speedInput.value, 10);
@@ -58,13 +60,16 @@ function startGame() {
     scoreEl.textContent = `Score: ${score.value}`;
   });
 
+  function onGameOver() {
+    gameoverEl.textContent = `Game Over! Score: ${score.value}\nPress R to restart.`;
+    gameoverEl.style.display = 'block';
+  }
+
   function update() {
     snake.applyNextDirection();
     const next = grid.getNeighbor(snake.body[0], snake.direction);
     if (snake.hitsSelf(next)) {
-      loop.state = GameState.GAME_OVER;
-      gameoverEl.textContent = `Game Over! Score: ${score.value}\nPress R to restart.`;
-      gameoverEl.style.display = 'block';
+      loop.gameOver();
       return;
     }
     snake.step(next);
@@ -86,7 +91,14 @@ function startGame() {
   if (navigator.xr) {
     renderer.enableAR();
   }
-  loop.addEventListener('tick', () => renderer.update());
+  loop.on('tick', () => renderer.update());
+  loop.on('pause', () => {
+    pausedEl.style.display = 'block';
+  });
+  loop.on('resume', () => {
+    pausedEl.style.display = 'none';
+  });
+  loop.on('gameover', onGameOver);
 
   scoreEl.textContent = 'Score: 0';
   showInstructions();

--- a/tests/GameLoopEvents.spec.ts
+++ b/tests/GameLoopEvents.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GameLoop } from '../src/core/GameLoop';
+
+describe('GameLoop events', () => {
+  it('emits pause and resume events', () => {
+    const loop = new GameLoop(() => {});
+    const pause = vi.fn();
+    const resume = vi.fn();
+    loop.on('pause', pause);
+    loop.on('resume', resume);
+    loop.togglePause(); // start running
+    loop.togglePause(); // pause again
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(pause).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits gameover event', () => {
+    const loop = new GameLoop(() => {});
+    const over = vi.fn();
+    loop.on('gameover', over);
+    loop.gameOver();
+    expect(over).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add paused HUD overlay
- extend GameLoop with pause/resume/gameover events
- update main logic to use events for overlays
- test GameLoop event emissions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dfb056ae08324881c5bf0ae43f5ff