### PR TITLE
Add sound feedback and renderer reset update

### DIFF
--- a/src/core/Fruit.ts
+++ b/src/core/Fruit.ts
@@ -1,11 +1,15 @@
 import type { Cell } from './Grid';
 import { Grid } from './Grid';
 import { Score } from './Score';
+import { playEat } from '../utils/Sound';
 
 export class Fruit extends EventTarget {
   cell: Cell;
 
-  constructor(private grid: Grid, private score: Score) {
+  constructor(
+    private grid: Grid,
+    private score: Score
+  ) {
     super();
     this.cell = { face: 0, u: 0, v: 0 };
   }
@@ -17,5 +21,6 @@ export class Fruit extends EventTarget {
   eat() {
     this.score.increment();
     this.dispatchEvent(new Event('fruit-eaten'));
+    playEat();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,18 @@ import { GameRenderer } from './render/GameRenderer';
 import { Fruit } from './core/Fruit';
 import { Score } from './core/Score';
 import { Input } from './core/Input';
+import { playDie } from './utils/Sound';
 
 const scoreEl = document.getElementById('score') as HTMLDivElement;
-const instructionsEl = document.getElementById('instructions') as HTMLDivElement;
+const instructionsEl = document.getElementById(
+  'instructions'
+) as HTMLDivElement;
 const gameoverEl = document.getElementById('gameover') as HTMLDivElement;
 const menuEl = document.getElementById('menu') as HTMLDivElement;
 const form = document.getElementById('start-form') as HTMLFormElement;
-const shapeSelect = document.getElementById('shape-select') as HTMLSelectElement;
+const shapeSelect = document.getElementById(
+  'shape-select'
+) as HTMLSelectElement;
 const gridInput = document.getElementById('grid-input') as HTMLInputElement;
 const speedInput = document.getElementById('speed-input') as HTMLInputElement;
 
@@ -50,7 +55,11 @@ function startGame() {
         ? new CylinderAdapter(size)
         : new CubeAdapter(size);
   grid = new Grid(size, adapter);
-  snake = new Snake({ face: 0, u: Math.floor(size / 2), v: Math.floor(size / 2) });
+  snake = new Snake({
+    face: 0,
+    u: Math.floor(size / 2),
+    v: Math.floor(size / 2),
+  });
   score = new Score();
   fruit = new Fruit(grid, score);
   fruit.spawn(snake.body);
@@ -63,6 +72,7 @@ function startGame() {
     const next = grid.getNeighbor(snake.body[0], snake.direction);
     if (snake.hitsSelf(next)) {
       loop.state = GameState.GAME_OVER;
+      playDie();
       gameoverEl.textContent = `Game Over! Score: ${score.value}\nPress R to restart.`;
       gameoverEl.style.display = 'block';
       return;
@@ -113,5 +123,3 @@ form.addEventListener('submit', (e) => {
 });
 
 menuEl.style.display = 'block';
-
-

--- a/src/render/GameRenderer.ts
+++ b/src/render/GameRenderer.ts
@@ -131,6 +131,10 @@ export class GameRenderer {
     }
     // Update fruit position as well
     this.fruitMesh.position.copy(this.adapter.toWorld(this.fruit.cell));
+
+    // Immediately position the new meshes so the next frame
+    // renders the correct state without a one-frame flicker.
+    this.update();
   }
 
   update() {

--- a/src/utils/Sound.ts
+++ b/src/utils/Sound.ts
@@ -1,0 +1,41 @@
+export function playTone(freq: number, duration: number) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    const AudioCtor =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!AudioCtor) {
+      return;
+    }
+    const ctx = new AudioCtor();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = freq;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    gain.gain.setValueAtTime(1, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + duration);
+    osc.stop(ctx.currentTime + duration);
+    osc.onended = () => ctx.close();
+  } catch {
+    // ignore failures (e.g., AudioContext not allowed)
+  }
+}
+
+export function playEat() {
+  playTone(880, 0.1);
+  if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+    navigator.vibrate(50);
+  }
+}
+
+export function playDie() {
+  playTone(220, 0.3);
+  if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+    navigator.vibrate([100, 50, 100]);
+  }
+}


### PR DESCRIPTION
## Summary
- improve `GameRenderer.reset` to reposition new meshes immediately
- add small audio/vibration utility and hook into fruit and game over events
- use typed union for optional `webkitAudioContext` to satisfy lint

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685dfb056ae08324881c5bf0ae43f5ff