### PR TITLE
Fix renderer reset to avoid lingering meshes

### DIFF
--- a/src/render/GameRenderer.ts
+++ b/src/render/GameRenderer.ts
@@ -55,10 +55,11 @@ export class GameRenderer {
       this.orientationActive = true;
     }
 
-    const geom = new THREE.BoxGeometry(1, 1, 1);
-    const mat = new THREE.MeshStandardMaterial({ color: 0x00ff00 });
     this.snakeMeshes = this.snake.body.map(() => {
-      const mesh = new THREE.Mesh(geom, mat);
+      const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(1, 1, 1),
+        new THREE.MeshStandardMaterial({ color: 0x00ff00 })
+      );
       this.scene.add(mesh);
       return mesh;
     });
@@ -73,10 +74,11 @@ export class GameRenderer {
   }
 
   private ensureSegments() {
-    const geom = new THREE.BoxGeometry(1, 1, 1);
-    const mat = new THREE.MeshStandardMaterial({ color: 0x00ff00 });
     while (this.snakeMeshes.length < this.snake.body.length) {
-      const mesh = new THREE.Mesh(geom, mat);
+      const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(1, 1, 1),
+        new THREE.MeshStandardMaterial({ color: 0x00ff00 })
+      );
       this.scene.add(mesh);
       this.snakeMeshes.push(mesh);
     }
@@ -122,10 +124,11 @@ export class GameRenderer {
     this.snakeMeshes = [];
 
     // Recreate segment meshes exactly matching the snake length
-    const geom = new THREE.BoxGeometry(1, 1, 1);
-    const mat = new THREE.MeshStandardMaterial({ color: 0x00ff00 });
     for (let i = 0; i < this.snake.body.length; i++) {
-      const mesh = new THREE.Mesh(geom, mat);
+      const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(1, 1, 1),
+        new THREE.MeshStandardMaterial({ color: 0x00ff00 })
+      );
       this.scene.add(mesh);
       this.snakeMeshes.push(mesh);
     }


### PR DESCRIPTION
## Summary
- ensure each snake segment mesh owns its geometry/material
- fully recreate meshes on `GameRenderer.reset`

## Testing
- `npm test --silent`
- `python -m py_compile $(git ls-files '*.py') && python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e03ff37708324a778a2d2af5b22e4