### PR TITLE
Fix missing GameState import

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { Grid } from './core/Grid';
 import { Snake } from './core/Snake';
-import { GameLoop } from './core/GameLoop';
+import { GameLoop, GameState } from './core/GameLoop';
 import { CubeAdapter } from './shapes/CubeAdapter';
 import { SphereAdapter } from './shapes/SphereAdapter';
 import { CylinderAdapter } from './shapes/CylinderAdapter';


### PR DESCRIPTION
## Summary
- fix reference to `GameState` in `main.ts`
- all tests pass

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test --silent`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_685e0706fdb88324a8b6d77e6cf18f88