### PR TITLE
Fix grid.random_cell on full grid

### DIFF
--- a/python/core/grid.py
+++ b/python/core/grid.py
@@ -20,24 +20,26 @@ class Grid:
             for u in range(self.size):
                 for v in range(self.size):
                     if not any(
-                        c.face == face and c.u == u and c.v == v
-                        for c in excluded
+                        c.face == face and c.u == u and c.v == v for c in excluded
                     ):
                         cells.append(Cell(face, u, v))
+        if not cells:
+            raise ValueError("Grid is full; no available cells")
         from random import choice
+
         return choice(cells)
 
     def get_neighbor(self, cell: Cell, direction: direction_type) -> Cell:
         face = cell.face
         u = cell.u
         v = cell.v
-        if direction == 'up':
+        if direction == "up":
             v -= 1
-        elif direction == 'down':
+        elif direction == "down":
             v += 1
-        elif direction == 'left':
+        elif direction == "left":
             u -= 1
-        elif direction == 'right':
+        elif direction == "right":
             u += 1
         if u < 0 or u >= self.size or v < 0 or v >= self.size:
             return self.adapter.wrap(Cell(face, u, v), direction)

--- a/tests_py/test_grid_full.py
+++ b/tests_py/test_grid_full.py
@@ -1,0 +1,20 @@
+from python.core.grid import Grid
+from python.shapes.cube_adapter import CubeAdapter
+from python.shapes.ishape_adapter import Cell
+
+
+def test_random_cell_raises_when_full():
+    adapter = CubeAdapter(2)
+    grid = Grid(2, adapter)
+    excluded = [
+        Cell(face, u, v)
+        for face in range(adapter.get_face_count())
+        for u in range(grid.size)
+        for v in range(grid.size)
+    ]
+    try:
+        grid.random_cell(excluded)
+    except ValueError:
+        assert True
+    else:
+        assert False, "Expected ValueError when grid is full"


### PR DESCRIPTION
## Summary
- raise an error when random_cell is called on a full grid
- add regression test for this edge case

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e0706fdb88324a8b6d77e6cf18f88