### PR TITLE
Fix extra updates in game loop

### DIFF
--- a/python/core/game_loop.py
+++ b/python/core/game_loop.py
@@ -44,7 +44,7 @@ class GameLoop:
         self.last_time = now
         if self.state == GameState.RUNNING:
             self.accumulator += delta
-            while self.accumulator >= self.TICK:
+            while self.accumulator >= self.TICK and self.state == GameState.RUNNING:
                 self.update(self.TICK)
                 self.accumulator -= self.TICK
         time.sleep(0.01)

--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -67,7 +67,10 @@ export class GameLoop extends EventTarget {
     this.lastTime = time;
     if (this.state === GameState.RUNNING) {
       this.accumulator += delta;
-      while (this.accumulator >= GameLoop.TICK) {
+      while (
+        this.accumulator >= GameLoop.TICK &&
+        this.state === GameState.RUNNING
+      ) {
         this.update(GameLoop.TICK / 1000);
         this.emit('tick');
         this.accumulator -= GameLoop.TICK;


### PR DESCRIPTION
## Summary
- stop GameLoop update loop when the state becomes GAME_OVER
- ensure the Python loop follows the same behavior

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py') && python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e0706fdb88324a8b6d77e6cf18f88