### PR TITLE
Fix cylinder adapter wrapping logic

### DIFF
--- a/python/shapes/cylinder_adapter.py
+++ b/python/shapes/cylinder_adapter.py
@@ -70,6 +70,8 @@ class CylinderAdapter(IShapeAdapter):
                 u = 0
             if v < 0 and direction == "down":
                 return Cell(0, u, 0)
+            if v > last and direction == "up":
+                return Cell(0, u, last)
         elif face == 2:
             if u < 0:
                 u = last
@@ -77,4 +79,6 @@ class CylinderAdapter(IShapeAdapter):
                 u = 0
             if v < 0 and direction == "up":
                 return Cell(0, u, last)
+            if v > last and direction == "down":
+                return Cell(0, u, 0)
         return Cell((face), (u + self.size) % self.size, (v + self.size) % self.size)

--- a/src/shapes/CylinderAdapter.ts
+++ b/src/shapes/CylinderAdapter.ts
@@ -82,11 +82,13 @@ export class CylinderAdapter implements IShapeAdapter {
         if (u < 0) u = last;
         if (u > last) u = 0;
         if (v < 0 && dir === 'down') return { face: 0, u, v: 0 };
+        if (v > last && dir === 'up') return { face: 0, u, v: last };
         break;
       case 2: // bottom
         if (u < 0) u = last;
         if (u > last) u = 0;
         if (v < 0 && dir === 'up') return { face: 0, u, v: last };
+        if (v > last && dir === 'down') return { face: 0, u, v: 0 };
         break;
     }
     u = (u + this.size) % this.size;


### PR DESCRIPTION
## Summary
- fix missing cylinder cap wrap conditions in Python and TS implementations
- ensure autoplayer and geometry tests run correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e0c969b148324b458a1366f4c70ce