### PR TITLE
Fix GameLoop stopping logic

### DIFF
--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -40,7 +40,9 @@ export class GameLoop extends EventTarget {
 
   stop() {
     this.stopped = true;
-    cancelAnimationFrame(this.frame);
+    if (typeof cancelAnimationFrame !== 'undefined') {
+      cancelAnimationFrame(this.frame);
+    }
   }
 
   togglePause() {
@@ -57,6 +59,7 @@ export class GameLoop extends EventTarget {
   gameOver() {
     this.state = GameState.GAME_OVER;
     this.emit('gameover');
+    this.stop();
   }
 
   private tick = (time: number) => {

--- a/tests/GameLoopGameOver.spec.ts
+++ b/tests/GameLoopGameOver.spec.ts
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { GameLoop } from '../src/core/GameLoop';
+
+// Access private tick for simulation
+const tick = (loop: GameLoop) =>
+  (loop as unknown as { tick: (t: number) => void }).tick(performance.now());
+
+describe('GameLoop gameOver', () => {
+  it('cancels scheduled frames when game over', () => {
+    const loop = new GameLoop(() => {});
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+    const caf = vi.spyOn(window, 'cancelAnimationFrame');
+    loop.start();
+    loop.gameOver();
+    tick(loop); // run pending frame
+    expect(caf).toHaveBeenCalled();
+    raf.mockRestore();
+    caf.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- stop animation frames when `gameOver()` fires
- guard `stop()` against missing `cancelAnimationFrame`
- add regression test for `gameOver` stopping the loop

## Testing
- `npm test --silent`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e0c969b148324b458a1366f4c70ce