### PR TITLE
Fix grid random cell overflow

### DIFF
--- a/src/core/Grid.ts
+++ b/src/core/Grid.ts
@@ -22,6 +22,9 @@ export class Grid {
         }
       }
     }
+    if (cells.length === 0) {
+      throw new Error('Grid is full; no available cells');
+    }
     return cells[Math.floor(Math.random() * cells.length)];
   }
 

--- a/tests/GridFull.spec.ts
+++ b/tests/GridFull.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { Grid } from '../src/core/Grid';
+import { CubeAdapter } from '../src/shapes/CubeAdapter';
+
+const adapter = new CubeAdapter(2);
+const grid = new Grid(2, adapter);
+
+describe('Grid randomCell', () => {
+  it('throws when grid is full', () => {
+    const excluded = [] as { face: number; u: number; v: number }[];
+    for (let face = 0; face < adapter.getFaceCount(); face++) {
+      for (let u = 0; u < grid.size; u++) {
+        for (let v = 0; v < grid.size; v++) {
+          excluded.push({ face, u, v });
+        }
+      }
+    }
+    expect(() => grid.randomCell(excluded)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- throw an error when randomCell has no available cells
- add Node test for full grid

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e10e3d5908324b3f77462ad3f8107