### PR TITLE
Fix autoplayer wrapping logic

### DIFF
--- a/python/ai/autoplayer.py
+++ b/python/ai/autoplayer.py
@@ -12,14 +12,17 @@ def choose_direction(snake: Snake, grid: Grid, fruit: Fruit) -> direction_type:
     """Choose a naive direction toward the fruit avoiding immediate self collision."""
     head = snake.body[0]
     target = fruit.cell
+    grid_size = grid.size
     options: list[tuple[direction_type, float]] = []
     for direction in ("up", "down", "left", "right"):
         next_cell = grid.get_neighbor(head, direction)
         if snake.hits_self(next_cell):
             continue
-        dx = next_cell.u - target.u
-        dy = next_cell.v - target.v
-        dist = abs(dx) + abs(dy)
+        du = abs(next_cell.u - target.u)
+        dv = abs(next_cell.v - target.v)
+        du = min(du, grid_size - du)
+        dv = min(dv, grid_size - dv)
+        dist = du + dv
         options.append((direction, dist))
     if not options:
         return random.choice(["up", "down", "left", "right"])


### PR DESCRIPTION
## Summary
- improve Python autoplayer to account for grid wrapping when choosing paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e10e3d5908324b3f77462ad3f8107