### PR TITLE
PEP8 fixes, Dev Agent Breadcrumbs, and project docs (MIND/BODY/SOUL)

### DIFF
--- a/BODY.md
+++ b/BODY.md
@@ -1,0 +1,15 @@
+# BODY.md
+
+## Purpose
+Capture implementation structure for gameplay "body" systems.
+
+## Core Modules
+- `python/core/` contains deterministic game state and loop behavior.
+- `python/shapes/` contains surface adapters and wrap semantics.
+- `python/ai/` contains basic autonomous steering agents.
+
+## Testing Expectations
+Run these checks before merging:
+- `python -m py_compile $(git ls-files '*.py')`
+- `python -m pycodestyle $(git ls-files '*.py')`
+- `python -m pytest -q`

--- a/MIND.md
+++ b/MIND.md
@@ -1,0 +1,12 @@
+# MIND.md
+
+## Purpose
+Define planning intent and logic flow for the Snake AR/XR prototype.
+
+## Development Mindset
+- Prioritize deterministic core mechanics before rendering complexity.
+- Keep logic modules isolated from adapters and presentation.
+- Prefer small, testable functions with explicit data flow.
+
+## Dev Agent Breadcrumb Convention
+Use comments that begin with `Dev Agent Breadcrumb:` in Python gameplay paths to explain why a step exists (not just what it does).

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,12 @@
+# SOUL.md
+
+## Purpose
+Describe project values for maintainability and team handoff.
+
+## Project Values
+- Keep gameplay behavior readable and reproducible.
+- Favor explicit naming and straightforward control flow over cleverness.
+- Leave concise breadcrumbs for future contributors in non-obvious logic.
+
+## Scope Reminder
+This milestone targets Snake on cube/sphere/cylinder-like surfaces with reliable logic and test coverage.

--- a/python/ai/autoplayer.py
+++ b/python/ai/autoplayer.py
@@ -9,7 +9,7 @@ from ..core.fruit import Fruit
 
 
 def choose_direction(snake: Snake, grid: Grid, fruit: Fruit) -> direction_type:
-    """Choose a naive direction toward the fruit avoiding immediate self collision."""
+    """Choose a naive move toward fruit while avoiding self-collision."""
     head = snake.body[0]
     target = fruit.cell
     grid_size = grid.size
@@ -18,6 +18,8 @@ def choose_direction(snake: Snake, grid: Grid, fruit: Fruit) -> direction_type:
         next_cell = grid.get_neighbor(head, direction)
         if snake.hits_self(next_cell):
             continue
+        # Dev Agent Breadcrumb: use wrap-aware Manhattan distance as a compact
+        # heuristic so the autoplayer can operate on non-planar surfaces.
         du = abs(next_cell.u - target.u)
         dv = abs(next_cell.v - target.v)
         du = min(du, grid_size - du)

--- a/python/ai/simple_agent.py
+++ b/python/ai/simple_agent.py
@@ -1,8 +1,9 @@
 from random import choice
 from typing import List
 
-from ..core.snake import Snake
 from ..core.grid import direction_type
+from ..core.snake import Snake
+
 
 class SimpleAgent:
     """Trivial AI that picks a random non-opposite direction."""

--- a/python/core/fruit.py
+++ b/python/core/fruit.py
@@ -21,7 +21,6 @@ class Fruit:
         self._score_obj = score
         self._listeners = []
 
-
     def spawn(self, snake_body: list[Cell]) -> None:
         self.cell = self.grid.random_cell(snake_body)
 
@@ -35,4 +34,3 @@ class Fruit:
             self._score_obj.increment()
         for cb in list(self._listeners):
             cb()
-

--- a/python/core/game_loop.py
+++ b/python/core/game_loop.py
@@ -43,8 +43,13 @@ class GameLoop:
         delta = now - self.last_time
         self.last_time = now
         if self.state == GameState.RUNNING:
+            # Dev Agent Breadcrumb: accumulate frame deltas until a fixed
+            # simulation tick is available, then process deterministic updates.
             self.accumulator += delta
-            while self.accumulator >= self.TICK and self.state == GameState.RUNNING:
+            while (
+                self.accumulator >= self.TICK
+                and self.state == GameState.RUNNING
+            ):
                 self.update(self.TICK)
                 self.accumulator -= self.TICK
         time.sleep(0.01)

--- a/python/core/grid.py
+++ b/python/core/grid.py
@@ -19,8 +19,11 @@ class Grid:
         for face in range(self.adapter.get_face_count()):
             for u in range(self.size):
                 for v in range(self.size):
+                    # Dev Agent Breadcrumb: build a complete candidate list so
+                    # fruit spawning stays deterministic for a given RNG seed.
                     if not any(
-                        c.face == face and c.u == u and c.v == v for c in excluded
+                        c.face == face and c.u == u and c.v == v
+                        for c in excluded
                     ):
                         cells.append(Cell(face, u, v))
         if not cells:

--- a/python/core/snake.py
+++ b/python/core/snake.py
@@ -42,6 +42,8 @@ class Snake:
         self.grow_flag = True
 
     def hits_self(self, cell: Cell) -> bool:
+        # Dev Agent Breadcrumb: ignore the tail when not growing because
+        # it will move away during the same simulation step.
         body = self.body if self.grow_flag else self.body[:-1]
         return any(
             c.face == cell.face
@@ -50,7 +52,12 @@ class Snake:
             for c in body
         )
 
-    def out_of_bounds(self, cell: Cell, grid_size: int, face_count: int = 6) -> bool:
+    def out_of_bounds(
+        self,
+        cell: Cell,
+        grid_size: int,
+        face_count: int = 6,
+    ) -> bool:
         """Check if a cell lies outside the grid or allowed faces."""
         return (
             cell.u < 0

--- a/python/shapes/cylinder_adapter.py
+++ b/python/shapes/cylinder_adapter.py
@@ -81,4 +81,8 @@ class CylinderAdapter(IShapeAdapter):
                 return Cell(0, u, last)
             if v > last and direction == "down":
                 return Cell(0, u, 0)
-        return Cell((face), (u + self.size) % self.size, (v + self.size) % self.size)
+        return Cell(
+            face,
+            (u + self.size) % self.size,
+            (v + self.size) % self.size,
+        )

--- a/run_snake.py
+++ b/run_snake.py
@@ -29,6 +29,8 @@ def main(shape: str = "cube") -> None:
     fruit.on_eaten(on_fruit_eaten)
 
     def update(_dt: float) -> None:
+        # Dev Agent Breadcrumb: process input first, then movement/collision,
+        # then fruit/score updates to keep a predictable game-state pipeline.
         snake.apply_next_direction()
         next_cell = grid.get_neighbor(snake.body[0], snake.direction)
         if snake.hits_self(next_cell):
@@ -45,7 +47,6 @@ def main(shape: str = "cube") -> None:
             fruit.eat()
         print(f"Snake: {snake.body} Fruit: {fruit.cell} Score: {score.value}")
 
-
     loop = GameLoop(update)
     loop.start()
 
@@ -56,7 +57,9 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Run the Snake game on a cube, sphere, or cylinder surface."
+        description=(
+            "Run the Snake game on a cube, sphere, or cylinder surface."
+        )
     )
     parser.add_argument(
         "shape",

--- a/tests_py/test_fruit.py
+++ b/tests_py/test_fruit.py
@@ -9,10 +9,16 @@ def test_fruit_spawn_not_on_snake():
     adapter = CubeAdapter(3)
     grid = Grid(3, adapter)
     fruit = Fruit(grid)
-    snake_body = [Cell(0, 0, 0), Cell(0, 1, 0), Cell(0, 2, 0)]
+    snake_body = [
+        Cell(0, 0, 0),
+        Cell(0, 1, 0),
+        Cell(0, 2, 0),
+    ]
     fruit.spawn(snake_body)
     assert not any(
-        fruit.cell.face == c.face and fruit.cell.u == c.u and fruit.cell.v == c.v
+        fruit.cell.face == c.face
+        and fruit.cell.u == c.u
+        and fruit.cell.v == c.v
         for c in snake_body
     )
 
@@ -65,4 +71,3 @@ def test_eat_callback_sees_updated_score():
     fruit.on_eaten(on_eat)
     fruit.eat()
     assert seen == [1]
-


### PR DESCRIPTION
### Motivation
- Make the Python gameplay modules PEP8-compliant and clearer to follow by adding concise in-code breadcrumbs that document intent and deterministic logic flow.
- Improve maintainability by tightening formatting, fixing lint issues, and adding project guidance files describing agent conventions and testing expectations.
- Preserve and validate existing behavior via the test-suite to ensure changes are non-breaking for the core prototype.

### Description
- Performed a PEP8 pass across Python files, fixing line-lengths, blank-line issues and small formatting problems in `python/ai/*`, `python/core/*`, `python/shapes/*`, `run_snake.py`, and tests.
- Added `Dev Agent Breadcrumb:` comments to clarify key game-flow points in `python/core/game_loop.py`, `python/core/grid.py`, `python/core/snake.py`, `python/ai/autoplayer.py`, and `run_snake.py` to document deterministic tick accumulation, spawn candidate construction, tail handling during collision checks, heuristic choice, and update sequencing.
- Minor API/format tweaks for readability: reflowed long expressions, split function signatures for clarity, and normalized a `Cell` return construction in `python/shapes/cylinder_adapter.py`.
- Added project guidance files `MIND.md`, `BODY.md`, and `SOUL.md` describing planning intent, module responsibilities, breadcrumb conventions, and test expectations.
- Small tests formatting tweaks in `tests_py/test_fruit.py` to adhere to style checks without functional changes.

### Testing
- Ran Python static/format checks and tests: `python -m py_compile $(git ls-files '*.py')`, `python -m pycodestyle $(git ls-files '*.py')`, and `python -m pytest -q`, which all succeeded with `22 passed` Python tests.
- Ran the JS/TS test-suite: `npm test` which completed successfully (Vitest run: 15 test files, 22 tests passed).
- An attempted `npm test -- --runInBand` failed due to an unsupported Vitest CLI flag; this was an invocation error and not a repository test failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20812ef488324a2424e984b18d4d5)